### PR TITLE
Set ro.moz.ril.query_icc_count

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -1,0 +1,17 @@
+# Copyright (C) 2013 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ADDITIONAL_BUILD_PROPERTIES += \
+  ro.moz.ril.query_icc_count=true \
+  $(NULL)


### PR DESCRIPTION
Setting this property to true enables support for reading the number
of remaining unlock retries for an ICC lock on the emulator.
