### PR TITLE
Bug 919982: B2G RIL - Instantiate additional ril-daemon/rilproxy services.

### DIFF
--- a/init.goldfish.rc
+++ b/init.goldfish.rc
@@ -88,3 +88,107 @@ service qemud /system/bin/qemud
 
 service goldfish-logcat /system/bin/logcat -Q
     oneshot
+
+service ril-daemon1 /system/bin/rild -c 1
+    class main
+    socket rild1 stream 660 root radio
+    socket rild1-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy1 /system/bin/rilproxy -c 1
+    class main
+    socket rilproxy1 stream 660 root system
+    user root
+    group radio
+
+service ril-daemon2 /system/bin/rild -c 2
+    class main
+    socket rild2 stream 660 root radio
+    socket rild2-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy2 /system/bin/rilproxy -c 2
+    class main
+    socket rilproxy2 stream 660 root system
+    user root
+    group radio
+
+service ril-daemon3 /system/bin/rild -c 3
+    class main
+    socket rild3 stream 660 root radio
+    socket rild3-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy3 /system/bin/rilproxy -c 3
+    class main
+    socket rilproxy3 stream 660 root system
+    user root
+    group radio
+
+service ril-daemon4 /system/bin/rild -c 4
+    class main
+    socket rild4 stream 660 root radio
+    socket rild4-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy4 /system/bin/rilproxy -c 4
+    class main
+    socket rilproxy4 stream 660 root system
+    user root
+    group radio
+
+service ril-daemon5 /system/bin/rild -c 5
+    class main
+    socket rild5 stream 660 root radio
+    socket rild5-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy5 /system/bin/rilproxy -c 5
+    class main
+    socket rilproxy5 stream 660 root system
+    user root
+    group radio
+
+service ril-daemon6 /system/bin/rild -c 6
+    class main
+    socket rild6 stream 660 root radio
+    socket rild6-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy6 /system/bin/rilproxy -c 6
+    class main
+    socket rilproxy6 stream 660 root system
+    user root
+    group radio
+
+service ril-daemon7 /system/bin/rild -c 7
+    class main
+    socket rild7 stream 660 root radio
+    socket rild7-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy7 /system/bin/rilproxy -c 7
+    class main
+    socket rilproxy7 stream 660 root system
+    user root
+    group radio
+
+service ril-daemon8 /system/bin/rild -c 8
+    class main
+    socket rild8 stream 660 root radio
+    socket rild8-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log
+
+service rilproxy8 /system/bin/rilproxy -c 8
+    class main
+    socket rilproxy8 stream 660 root system
+    user root
+    group radio

--- a/ril/Android.mk
+++ b/ril/Android.mk
@@ -1,0 +1,16 @@
+# Copyright (C) 2013 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Number of ril-daemon/rilproxy instances.
+ADDITIONAL_BUILD_PROPERTIES += ro.moz.ril.numclients=9


### PR DESCRIPTION
Since [bug 814568](https://bugzilla.mozilla.org/show_bug.cgi?id=814568), we have 8 additional virtual modems in emulator.  They have been enabled for a long time but inactive because they're not connected to Gecko by additional rilproxy/ril-daemons.  This pull request adds those services in `init.goldfish.rc` and overrides Gecko preference **ril.numRadioInterfaces** to reflect the number of current active modems.

This pull request is for branch [b2g-4.3_r2.1](https://github.com/mozilla-b2g/device_generic_goldfish/tree/b2g-4.3_r2.1), which is forked from AOSP tag [android-4.3_r2.1](https://android.googlesource.com/device/generic/goldfish/+/android-4.3_r2.1).
