### PR TITLE
Bug 871475: add eth0 as default route but with metric 2. r=mwu

### DIFF
--- a/ril/Android.mk
+++ b/ril/Android.mk
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+LOCAL_PATH := $(call my-dir)
+
 ADDITIONAL_BUILD_PROPERTIES += \
   ro.moz.ril.query_icc_count=true \
   $(NULL)
+
+.PHONY: patch-init-goldfish-sh
+patch-init-goldfish-sh: PRIVATE_INITSH := $(TARGET_OUT_ETC)/init.goldfish.sh
+patch-init-goldfish-sh: PRIVATE_PATCH := $(LOCAL_PATH)/init.goldfish.sh.patch
+patch-init-goldfish-sh: $(TARGET_OUT_ETC)/init.goldfish.sh \
+                        $(LOCAL_PATH)/init.goldfish.sh.patch
+	$(hide) if [ -n "`cat $(PRIVATE_INITSH) | grep '^route add'`" ]; then \
+	  echo "patch: $(PRIVATE_INITSH) < $(notdir $(PRIVATE_PATCH))"; \
+	  patch -s $(PRIVATE_INITSH) $(PRIVATE_PATCH); \
+	fi
+
+# INSTALLED_RAMDISK_TARGET have not been assigned at the time all Android.mk
+# files are included.
+$(PRODUCT_OUT)/ramdisk.img: patch-init-goldfish-sh

--- a/ril/init.goldfish.sh.patch
+++ b/ril/init.goldfish.sh.patch
@@ -1,0 +1,19 @@
+diff --git a/rootdir/etc/init.goldfish.sh b/rootdir/etc/init.goldfish.sh
+index ece75b4..e68ab47 100755
+--- a/rootdir/etc/init.goldfish.sh
++++ b/rootdir/etc/init.goldfish.sh
+@@ -1,13 +1,13 @@
+ #!/system/bin/sh
+ 
+ # Setup networking when boot starts
+ ifconfig eth0 10.0.2.15 netmask 255.255.255.0 up
+-route add default gw 10.0.2.2 dev eth0
++ip route add default via 10.0.2.2 dev eth0 metric 2
+ 
+ # ro.kernel.android.qemud is normally set when we
+ # want the RIL (radio interface layer) to talk to
+ # the emulated modem through qemud.
+ #
+ # However, this will be undefined in two cases:
+ #
+ # - When we want the RIL to talk directly to a guest


### PR DESCRIPTION
To enable telephony data connection emulation while keeping nomral
network function when data connection is not enabled, eth0 is reserved
as the default route but with its metric value set to a higher 2.
