### PR TITLE
Bug 990445 - B2G Emulator: Add supportedNetworkTypes configuration for e...

### DIFF
--- a/ril/Android.mk
+++ b/ril/Android.mk
@@ -16,6 +16,7 @@ LOCAL_PATH := $(call my-dir)
 
 ADDITIONAL_BUILD_PROPERTIES += \
   ro.moz.ril.query_icc_count=true \
+  ro.moz.ril.0.network_types=gsm,wcdma,cdma,evdo \
   $(NULL)
 
 .PHONY: patch-init-goldfish-sh


### PR DESCRIPTION
Please see [bug 990445](https://bugzilla.mozilla.org/show_bug.cgi?id=990445).
