### PR TITLE
Bug 1163483 - Maintain only 2 rild/rilproxy on emulator-l

### DIFF
--- a/init.goldfish.rc
+++ b/init.goldfish.rc
@@ -104,105 +104,14 @@ service fuse_sdcard /system/bin/sdcard -u 1023 -g 1023 -d /mnt/media_rw/sdcard /
 service ril-daemon1 /system/bin/rild -c 1
     class main
     socket rild1 stream 660 root radio
-    socket rild1-debug stream 660 radio system
+    socket rild-debug1 stream 660 radio system
     user root
     group radio cache inet misc audio log
 
 service rilproxy1 /system/bin/rilproxy -c 1
     class main
-    socket rilproxy1 stream 660 root system
-    user root
-    group radio
-
-service ril-daemon2 /system/bin/rild -c 2
-    class main
-    socket rild2 stream 660 root radio
-    socket rild2-debug stream 660 radio system
-    user root
-    group radio cache inet misc audio log
-
-service rilproxy2 /system/bin/rilproxy -c 2
-    class main
-    socket rilproxy2 stream 660 root system
-    user root
-    group radio
-
-service ril-daemon3 /system/bin/rild -c 3
-    class main
-    socket rild3 stream 660 root radio
-    socket rild3-debug stream 660 radio system
-    user root
-    group radio cache inet misc audio log
-
-service rilproxy3 /system/bin/rilproxy -c 3
-    class main
-    socket rilproxy3 stream 660 root system
-    user root
-    group radio
-
-service ril-daemon4 /system/bin/rild -c 4
-    class main
-    socket rild4 stream 660 root radio
-    socket rild4-debug stream 660 radio system
-    user root
-    group radio cache inet misc audio log
-
-service rilproxy4 /system/bin/rilproxy -c 4
-    class main
-    socket rilproxy4 stream 660 root system
-    user root
-    group radio
-
-service ril-daemon5 /system/bin/rild -c 5
-    class main
-    socket rild5 stream 660 root radio
-    socket rild5-debug stream 660 radio system
-    user root
-    group radio cache inet misc audio log
-
-service rilproxy5 /system/bin/rilproxy -c 5
-    class main
-    socket rilproxy5 stream 660 root system
-    user root
-    group radio
-
-service ril-daemon6 /system/bin/rild -c 6
-    class main
-    socket rild6 stream 660 root radio
-    socket rild6-debug stream 660 radio system
-    user root
-    group radio cache inet misc audio log
-
-service rilproxy6 /system/bin/rilproxy -c 6
-    class main
-    socket rilproxy6 stream 660 root system
-    user root
-    group radio
-
-service ril-daemon7 /system/bin/rild -c 7
-    class main
-    socket rild7 stream 660 root radio
-    socket rild7-debug stream 660 radio system
-    user root
-    group radio cache inet misc audio log
-
-service rilproxy7 /system/bin/rilproxy -c 7
-    class main
-    socket rilproxy7 stream 660 root system
-    user root
-    group radio
-
-service ril-daemon8 /system/bin/rild -c 8
-    class main
-    socket rild8 stream 660 root radio
-    socket rild8-debug stream 660 radio system
-    user root
-    group radio cache inet misc audio log
-
-service rilproxy8 /system/bin/rilproxy -c 8
-    class main
-    socket rilproxy8 stream 660 root system
-    user root
+    socket rilproxy1 stream 660 radio radio
+    user radio
     group radio
 
 service dhcpcd_eth1 /system/bin/dhcpcd -ABKLG


### PR DESCRIPTION
Please see [bug 1163483](https://bugzilla.mozilla.org/show_bug.cgi?id=1163483).
