### PR TITLE
Bug 1207040 - Mochitest shutdown crash on the compositor thread

### DIFF
--- a/opengl/system/OpenglSystemCommon/ThreadInfo.cpp
+++ b/opengl/system/OpenglSystemCommon/ThreadInfo.cpp
@@ -24,6 +24,7 @@ static void tlsDestruct(void *ptr)
         EGLThreadInfo *ti = (EGLThreadInfo *)ptr;
         delete ti->hostConn;
         delete ti;
+        ((intptr_t *)__get_tls())[TLS_SLOT_OPENGL] = NULL;
     }
 }
 


### PR DESCRIPTION
Please see [Bug 1207040](https://bugzilla.mozilla.org/show_bug.cgi?id=1207040).

Cherry-pick the fix [1] from upstream.

[1] https://android.googlesource.com/device/generic/goldfish/+/a1de8e2f5e4c29341be01bae364a54d92d14c742%5E!/#F0
